### PR TITLE
chore: add PR policy to CLAUDE.md and auto-select issue in solve-issue skill

### DIFF
--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -3,10 +3,27 @@ name: solve-issue
 description: Solve a GitHub issue end-to-end — read the issue, plan the work, implement it on a branch, commit, and open a pull request.
 disable-model-invocation: true
 argument-hint: <issue-number>
-allowed-tools: Bash(gh issue view *), Bash(gh pr create *), Bash(git switch *), Bash(git add *), Bash(git commit *), Bash(git push *)
+allowed-tools: Bash(gh issue view *), Bash(gh issue list *), Bash(gh pr create *), Bash(git switch *), Bash(git add *), Bash(git commit *), Bash(git push *)
 ---
 
 Solve GitHub issue $ARGUMENTS end-to-end following these steps in order:
+
+## Step 0 — Resolve the issue number (only when no argument is given)
+
+If `$ARGUMENTS` is empty, you must determine which issue to solve before proceeding.
+
+1. Run:
+   ```bash
+   gh issue list --state open --json number,title,body
+   ```
+2. Parse each issue's `## Blocked by` section (if present) to build a full dependency graph.
+3. Find every issue whose blockers are either closed or non-existent — these are the **unblocked** issues.
+4. **Recommend the unblocked issue with the lowest number** as the natural next step, and explain:
+   - Why it is unblocked (no open blockers)
+   - Which other issues depend on it (i.e. what solving it will unlock)
+   - The full dependency chain so the user can see the big picture
+5. Ask the user which issue they want to solve. Use the recommended issue as the default choice.
+6. Once the user picks an issue number, set that as the target and continue to Step 1.
 
 ## Step 1 — Read the issue
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,13 @@ The client uses `DB_HOST` env var (default: `localhost:9042`) to set the connect
 |---|---|---|
 | `DB_HOST` | `localhost:9042` | DB connection target for Rust client |
 | `GF_SECURITY_ADMIN_PASSWORD` | `admin` | Grafana admin password |
+
+## Pull Request Policy
+
+**One PR solves one problem.** Each pull request must correspond to exactly one GitHub issue or one cohesive concern. Do not bundle unrelated changes.
+
+**Grouping guideline:**
+- Claude configuration changes (`CLAUDE.md`, `.claude/skills/**`) may be combined in one PR since they form a single concern.
+- Project code changes (Docker Compose files, Prometheus config, Grafana dashboards, Rust client) must each be in their own PR tied to a specific issue.
+
+When creating a PR, always reference the issue it closes with `Closes #N` in the commit message and PR body.


### PR DESCRIPTION
## Summary
- Add a one-PR-one-problem policy to `CLAUDE.md` so future sessions know how to scope pull requests
- Add Step 0 to the `solve-issue` skill so it recommends the next unblocked issue when invoked without an argument

## Changes
- `CLAUDE.md`: new **Pull Request Policy** section documenting the one-PR-one-problem rule and the grouping guideline (Claude config files may be combined; project code changes must be separate)
- `.claude/skills/solve-issue/SKILL.md`: new Step 0 that lists open issues, parses `## Blocked by` sections to build a dependency graph, and recommends the lowest-numbered unblocked issue with a rationale before asking the user to confirm

## How to verify
- [x] Run `/solve-issue` with no argument — it should list open issues, show the dependency chain, and recommend #1 as the next step
- [x] `CLAUDE.md` contains a "Pull Request Policy" section describing the one-PR-one-problem rule