### PR TITLE
chore: add Step 9 to solve-issue skill to return to main and pull after PR

### DIFF
--- a/.claude/skills/solve-issue/SKILL.md
+++ b/.claude/skills/solve-issue/SKILL.md
@@ -3,7 +3,7 @@ name: solve-issue
 description: Solve a GitHub issue end-to-end — read the issue, plan the work, implement it on a branch, commit, and open a pull request.
 disable-model-invocation: true
 argument-hint: <issue-number>
-allowed-tools: Bash(gh issue view *), Bash(gh issue list *), Bash(gh pr create *), Bash(git switch *), Bash(git add *), Bash(git commit *), Bash(git push *)
+allowed-tools: Bash(gh issue view *), Bash(gh issue list *), Bash(gh pr create *), Bash(git switch *), Bash(git add *), Bash(git commit *), Bash(git push *), Bash(git pull *)
 ---
 
 Solve GitHub issue $ARGUMENTS end-to-end following these steps in order:
@@ -113,3 +113,14 @@ EOF
 ```
 
 Print the PR URL at the end.
+
+## Step 9 — Return to main and pull
+
+After the PR is open, switch back to `main` and pull the latest changes so the workspace is ready for the next issue:
+
+```bash
+git switch main
+git pull
+```
+
+Inform the user that the workspace is back on `main` and ready for the next issue.


### PR DESCRIPTION
## Summary
- Adds a Step 9 to the `solve-issue` skill that switches back to `main` and runs `git pull` after the PR is created

## Changes
- `.claude/skills/solve-issue/SKILL.md`: added Step 9 and `git pull` to allowed-tools

## How to verify
- [ ] Run `/solve-issue` on any open issue and confirm that after the PR is opened, the skill switches to `main` and pulls