### PR TITLE
Add Prometheus scrape config (prometheus/prometheus.yml)

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -2,3 +2,12 @@
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
 global:
   scrape_interval: 15s
+
+scrape_configs:
+  - job_name: cassandra
+    static_configs:
+      - targets: ["host.docker.internal:7070"]
+
+  - job_name: scylladb
+    static_configs:
+      - targets: ["host.docker.internal:9180"]


### PR DESCRIPTION
## Summary
- Add `scrape_configs` to `prometheus/prometheus.yml` with jobs for both Cassandra (JMX Exporter at `:7070`) and ScyllaDB (native metrics at `:9180`)

## Changes
- `prometheus/prometheus.yml`: added `scrape_configs` with `cassandra` and `scylladb` jobs; the volume mount into the Prometheus container was already in place from #1

## How to verify
- [x] Start the base stack: `docker compose -f docker-compose.base.yml up -d`
- [x] Open `http://localhost:9090/targets` — both `cassandra` and `scylladb` jobs should appear as active targets (health will show `down` until the DB services are running, which is expected)
- [x] Tear down: `docker compose -f docker-compose.base.yml down`

## Follow-up
Automated verification of these criteria will be handled by #14 (GitHub Actions CI for Prometheus config validation).

Closes #2