### PR TITLE
Add JMX Exporter config: latency, throughput, and cache metrics

### DIFF
--- a/jmx-exporter/cassandra.yml
+++ b/jmx-exporter/cassandra.yml
@@ -1,9 +1,35 @@
 # Connects to Cassandra's JMX port exposed within the Docker network.
 # Credentials are required because LOCAL_JMX=no enables CassandraLoginModule.
 # https://github.com/apache/cassandra/blob/trunk/conf/cassandra-env.sh
-# Issue #6 will narrow these rules to specific metrics (latency, throughput, cache hit rate).
 hostPort: cassandra:7199
 username: cassandra
 password: cassandra
 rules:
-  - pattern: ".*"
+  # ClientRequest latency metrics: p50, p75, p95, p99, Mean (microseconds)
+  # Pattern based on https://github.com/oleg-glushak/cassandra-prometheus-jmx
+  - pattern: 'org.apache.cassandra.metrics<type=ClientRequest, scope=(Read|Write|RangeSlice|CASRead|CASWrite), name=Latency><>(50thPercentile|75thPercentile|95thPercentile|99thPercentile|Mean|Count)'
+    name: cassandra_client_request_latency_$2
+    labels:
+      operation: $1
+    type: GAUGE
+
+  # ClientRequest throughput: total count for calculating RPS
+  - pattern: 'org.apache.cassandra.metrics<type=ClientRequest, scope=(Read|Write|RangeSlice|CASRead|CASWrite), name=TotalLatency><>Count'
+    name: cassandra_client_request_total
+    labels:
+      operation: $1
+    type: COUNTER
+
+  # Cache hit rate: KeyCache and RowCache
+  - pattern: 'org.apache.cassandra.metrics<type=Cache, scope=(KeyCache|RowCache), name=HitRate><>Value'
+    name: cassandra_cache_hit_rate
+    labels:
+      cache: $1
+    type: GAUGE
+
+  # Cache requests and hits for calculating hit rate
+  - pattern: 'org.apache.cassandra.metrics<type=Cache, scope=(KeyCache|RowCache), name=(Requests|Hits)><>Count'
+    name: cassandra_cache_$2_total
+    labels:
+      cache: $1
+    type: COUNTER


### PR DESCRIPTION
## Summary
- Replace the catch-all `.*` pattern in `jmx-exporter/cassandra.yml` with specific JMX bean rules scoped to the metrics required by the acceptance criteria

## Changes
- `jmx-exporter/cassandra.yml`: four targeted rules replacing the single `.*` wildcard:
  - **ClientRequest latency** (p50/p75/p95/p99/Mean) per operation (Read, Write, RangeSlice, CASRead, CASWrite)
  - **ClientRequest total** count per operation for RPS calculation
  - **Cache hit rate** for KeyCache and RowCache
  - **Cache request/hit counts** for KeyCache and RowCache

## How to verify
- [ ] Start the stack: `docker compose -f docker-compose.base.yml -f docker-compose.cassandra.yml up -d`
- [ ] Wait for Cassandra to be healthy (~60–90s): `docker inspect --format='{{.State.Health.Status}}' cassandra-scylladb-monitor-cassandra-1`
- [ ] Check metrics: `curl -s http://localhost:7070/metrics | grep -E "^cassandra_"` — should show `cassandra_client_request_latency_*`, `cassandra_client_request_total`, `cassandra_cache_hit_rate`, `cassandra_cache_*_total`
- [ ] Check Prometheus target: `http://localhost:9090/targets` — cassandra target should show **UP**

Closes #6